### PR TITLE
fix(ci): resolve secrets context error causing 0 jobs executed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           coverage: none
 
       - name: PHP syntax check
-        run: find . -name "*.php" -not -path "./vendor/*" -not -path "./wordpress/*" | xargs php -l
+        run: find . -name "*.php" -not -path "./vendor/*" -not -path "./wordpress/*" -print0 | xargs -0 php -l
 
   build:
     name: Build (PHP ${{ matrix.php }} / OpenSwoole ${{ matrix.openswoole }})
@@ -42,6 +42,11 @@ jobs:
           - php: "8.4"
             openswoole: "22.1.5"
 
+    env:
+      # Expose whether the deploy key secret is set so step-level if: conditions
+      # can reference it (secrets context is not available in if: expressions).
+      HAS_DEPLOY_KEY: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +57,7 @@ jobs:
       # skipped and composer will fall back to the HTTPS token below.
       # ---------------------------------------------------------------
       - name: Configure SSH deploy key
-        if: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
+        if: env.HAS_DEPLOY_KEY == 'true'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.COMPOSER_DEPLOY_KEY }}
@@ -95,7 +100,7 @@ jobs:
             {"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}
 
       - name: PHP syntax check (vendor-free)
-        run: find . -name "*.php" -not -path "./vendor/*" -not -path "./wordpress/*" | xargs php -l
+        run: find . -name "*.php" -not -path "./vendor/*" -not -path "./wordpress/*" -print0 | xargs -0 php -l
 
   integration:
     name: Integration (PHP ${{ matrix.php }} / OpenSwoole ${{ matrix.openswoole }})
@@ -107,6 +112,9 @@ jobs:
       matrix:
         php: ["8.2", "8.3"]
         openswoole: ["22.1.5"]
+
+    env:
+      HAS_DEPLOY_KEY: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
 
     services:
       mysql:
@@ -128,7 +136,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure SSH deploy key
-        if: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
+        if: env.HAS_DEPLOY_KEY == 'true'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.COMPOSER_DEPLOY_KEY }}
@@ -242,7 +250,7 @@ jobs:
         run: |
           # Fire 5 concurrent requests and collect exit codes
           PIDS=()
-          for i in $(seq 1 5); do
+          for _idx in $(seq 1 5); do
             curl -sf --max-time 10 http://localhost:8889/ > /dev/null &
             PIDS+=($!)
           done


### PR DESCRIPTION
## Summary

- Fixes CI pipeline failing with 0 jobs executed (issue #11)
- Root cause: `secrets` context is not available in step-level `if:` expressions in GitHub Actions
- Fix: expose secret presence as a job-level `env` var (`HAS_DEPLOY_KEY`) and reference `env.HAS_DEPLOY_KEY` in step conditions

## Root Cause

Lines 55 and 131 used:
```yaml
if: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
```

GitHub Actions does not allow the `secrets` context in step-level `if:` conditions. This causes the entire workflow to fail at parse/validation time with 0 jobs executed. The available contexts at step `if:` scope are: `env`, `github`, `inputs`, `job`, `matrix`, `needs`, `runner`, `steps`, `strategy`, `vars`.

## Fix

Added a job-level `env` block to each affected job:
```yaml
env:
  HAS_DEPLOY_KEY: ${{ secrets.COMPOSER_DEPLOY_KEY != '' }}
```

Then changed step conditions to:
```yaml
if: env.HAS_DEPLOY_KEY == 'true'
```

## Additional Fixes (actionlint/shellcheck)

- **SC2038**: `find | xargs` → `find -print0 | xargs -0` to handle filenames with spaces/special chars (lines 28, 98)
- **SC2034**: renamed unused loop variable `i` to `_idx` in concurrent request test (line 245)

## Verification

`actionlint` exits 0 with no errors on the fixed workflow file.

## Runtime Testing

- **Risk classification:** Low (CI config only — no application code changed)
- **Testing level:** self-assessed + actionlint verified
- **Verification:** `docker run --rm rhysd/actionlint:latest` exits 0

Closes #11