### PR TITLE
chore: ignore .agents/loop-state/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 wordpress/
 .env
 
+.agents/loop-state/


### PR DESCRIPTION
## Summary

- Adds `.agents/loop-state/` to `.gitignore` to prevent framework loop-state files from being tracked
- These files are generated by the aidevops pulse supervisor and should not be committed

## Changes

- `.gitignore`: add `.agents/loop-state/` entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude local agent-related directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->