### PR TITLE
GH#24: fix(ci): remove empty job-level env: block in phpunit-tests.yml

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,7 +56,6 @@ jobs:
         php: ["8.2"]
         openswoole: ["22.1.5"]
 
-    env:
     services:
       mysql:
         image: mysql:8.0


### PR DESCRIPTION
## Summary

Removes the empty `env:` block at line 59 of `.github/workflows/phpunit-tests.yml` that caused GitHub Actions to fail with "This run likely failed because of a workflow file issue."

## Root Cause

An empty `env:` block (no key-value pairs) at the job level is invalid YAML for GitHub Actions. The workflow-level `env:` block (line 32) already defines all required variables (`WP_URL`, `DB_NAME`, etc.), making the empty job-level block both redundant and broken.

## Change

- Removed the empty `env:` block at line 59 (1-line deletion)
- No functional change — all env vars remain available via the workflow-level `env:` block

## Runtime Testing

- **Risk level**: Low (CI config change, no application code)
- **Level**: self-assessed
- **Verification**: YAML structure validated by inspection; the fix is a single-line deletion of an empty block

## Files Changed

- `.github/workflows/phpunit-tests.yml` — removed empty job-level `env:` block

Closes #24


---
[aidevops.sh](https://aidevops.sh) v3.5.179 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 1m and 2,205 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

---

**Note:** This release contains no user-facing changes. The update addresses internal infrastructure configuration only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->