### PR TITLE
fix(ci): skip wp core download — Composer already installs WordPress

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -119,16 +119,20 @@ jobs:
           COMPOSER_AUTH: >-
             {"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}
 
-      - name: Install WordPress via WP-CLI
+      - name: Configure and install WordPress via WP-CLI
         run: |
-          wp core download --path=wordpress --allow-root
+          # WordPress core files are already present — installed by Composer via
+          # johnpbloch/wordpress into the wordpress/ directory. Running
+          # `wp core download` here would fail with "WordPress files seem to
+          # already be present here." Skip straight to config + install.
           wp config create \
             --path=wordpress \
             --dbname="${DB_NAME}" \
             --dbuser="${DB_USER}" \
             --dbpass="${DB_PASSWORD}" \
             --dbhost="${DB_HOST}" \
-            --allow-root
+            --allow-root \
+            --force
           wp core install \
             --path=wordpress \
             --url="${WP_URL}" \


### PR DESCRIPTION
## Problem

The `Install WordPress via WP-CLI` step failed on master 3+ consecutive times with:

```
Error: WordPress files seem to already be present here.
Process completed with exit code 1.
```

Affected runs: 23703609430, 23696732447, 23687653024, 23667208498.

## Root Cause

`composer install` (via `johnpbloch/wordpress` in `composer.json`) installs WordPress 6.9.4 into the `wordpress/` directory **before** the WP-CLI step runs. When `wp core download --path=wordpress` executes, it finds files already present and exits with code 1.

This is a sequencing conflict: Composer is the authoritative WordPress installer in this project; WP-CLI's download step is redundant and incompatible.

## Fix

Remove `wp core download` entirely. The WordPress files are already present from Composer. Replace the step with:

1. `wp config create --force` — creates `wp-config.php` (the `--force` flag handles any stale config from a previous run)
2. `wp core install` — runs the database install against the existing files

Step renamed from "Install WordPress via WP-CLI" → "Configure and install WordPress via WP-CLI" to reflect the actual operation.

## Testing

- Risk level: **Low** (CI config change only, no application code modified)
- Verification: CI run on this PR branch will confirm the fix

## Files Changed

- `.github/workflows/phpunit-tests.yml` — remove `wp core download`, add `--force` to `wp config create`, rename step

Closes #26

---
[aidevops.sh](https://aidevops.sh) v3.5.179 plugin for [Claude Code](https://claude.ai) with claude-sonnet-4-6 spent 8m on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the continuous integration test setup process to streamline WordPress configuration and installation during automated testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->