### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: PHP Lint (8.2)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -39,7 +39,7 @@ jobs:
         openswoole: ["22.1.5", "22.1.2"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php }} with OpenSwoole ${{ matrix.openswoole }}
         uses: shivammathur/setup-php@v2
@@ -60,7 +60,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -116,7 +116,7 @@ jobs:
           --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php }} with OpenSwoole ${{ matrix.openswoole }}
         uses: shivammathur/setup-php@v2
@@ -133,7 +133,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
           --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php }} with OpenSwoole ${{ matrix.openswoole }}
         uses: shivammathur/setup-php@v2
@@ -78,7 +78,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -147,7 +147,7 @@ jobs:
           done
 
       - name: Set up Node.js for Playwright
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-php${{ matrix.php }}-openswoole${{ matrix.openswoole }}
           path: /tmp/playwright-report/
@@ -300,7 +300,7 @@ jobs:
 
       - name: Upload Playwright results JSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results-php${{ matrix.php }}-openswoole${{ matrix.openswoole }}
           path: /tmp/playwright-results.json

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -73,7 +73,7 @@ jobs:
           --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php }} with OpenSwoole ${{ matrix.openswoole }}
         uses: shivammathur/setup-php@v2
@@ -90,7 +90,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload PHPUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: phpunit-results-php${{ matrix.php }}-openswoole${{ matrix.openswoole }}
           path: |


### PR DESCRIPTION
## Summary

Bumps four GitHub Actions to their Node.js 24 versions ahead of the June 2, 2026 forced migration and September 16, 2026 removal deadline.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |

`shivammathur/setup-php@v2` (already on Node 24) and `softprops/action-gh-release` (not used in this repo) required no changes.

## Files changed

- EDIT: `.github/workflows/ci.yml` — checkout ×3, cache ×2
- EDIT: `.github/workflows/e2e-tests.yml` — checkout ×1, cache ×1, setup-node ×1, upload-artifact ×2
- EDIT: `.github/workflows/phpunit-tests.yml` — checkout ×1, cache ×1, upload-artifact ×1

## Verification

After merge, trigger any workflow run and confirm no Node.js 20 deprecation warnings appear in the annotations.

Resolves #32